### PR TITLE
Fix Windows build

### DIFF
--- a/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
+++ b/soh/soh/Enhancements/custom-message/CustomMessageManager.cpp
@@ -494,7 +494,7 @@ void CustomMessage::InsertNames(std::vector<CustomMessage> toInsert){
         if ((capital.size() > a) && (capital[a] = true)){
             temp.Capitalize();
         } 
-        Replace(std::move("[[" + std::to_string(a+1) + "]]"), temp); 
+        Replace("[[" + std::to_string(a+1) + "]]", temp); 
     }
 }
 

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -73,7 +73,7 @@ uint8_t HintText::GetObscureSize() const{
     return obscureText.size();
 }
 
-const CustomMessage& HintText::GetMessage(uint8_t selection) const {
+const CustomMessage& HintText::GetHintMessage(uint8_t selection) const {
     auto ctx = Rando::Context::GetInstance();
     if (ctx->GetOption(RSK_HINT_CLARITY).Is(RO_HINT_CLARITY_OBSCURE)) {
         return GetObscure(selection);

--- a/soh/soh/Enhancements/randomizer/3drando/hints.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.hpp
@@ -41,7 +41,7 @@ public:
     const CustomMessage& GetAmbiguous(uint8_t selection) const;
     uint8_t GetAmbiguousSize() const;
     uint8_t GetObscureSize() const;
-    const CustomMessage& GetMessage(uint8_t selection = 0) const;
+    const CustomMessage& GetHintMessage(uint8_t selection = 0) const;
     const CustomMessage GetMessageCopy() const;
     bool operator==(const HintText& right) const;
     bool operator!=(const HintText& right) const;

--- a/soh/soh/Enhancements/randomizer/context.cpp
+++ b/soh/soh/Enhancements/randomizer/context.cpp
@@ -174,7 +174,7 @@ std::vector<RandomizerCheck> Context::GetLocations(const std::vector<RandomizerC
 }
 
 void Context::ClearItemLocations() {
-    for (uint i = 0; i < itemLocationTable.size(); i++) {
+    for (size_t i = 0; i < itemLocationTable.size(); i++) {
         GetItemLocation(static_cast<RandomizerCheck>(i))->ResetVariables();
     }
 }

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -236,7 +236,7 @@ const std::vector<std::string> Hint::GetAllMessageStrings(MessageFormat format) 
   std::vector<std::string> hintMessages = {};
   uint8_t numMessages = GetNumberOfMessages();
   for (int c = 0; c < numMessages; c++){
-    hintMessages.push_back(GetMessage(format, c).GetForCurrentLanguage(format));
+    hintMessages.push_back(GetHintMessage(format, c).GetForCurrentLanguage(format));
   }
   return hintMessages;
 }
@@ -286,7 +286,7 @@ const HintText Hint::GetHintText(uint8_t id) const {
   }
 }
 
-const CustomMessage Hint::GetMessage(MessageFormat format, uint8_t id) const {
+const CustomMessage Hint::GetHintMessage(MessageFormat format, uint8_t id) const {
   auto ctx = Rando::Context::GetInstance();
   CustomMessage hintText = CustomMessage("ERROR:NO MESSAGE FOUND");
 
@@ -301,22 +301,22 @@ const CustomMessage Hint::GetMessage(MessageFormat format, uint8_t id) const {
     }
   } else if (hintType == HINT_TYPE_ALTAR_CHILD){
     if (ctx->GetOption(RSK_TOT_ALTAR_HINT)){
-      hintText = StaticData::hintTextTable[RHT_CHILD_ALTAR_STONES].GetMessage();
+      hintText = StaticData::hintTextTable[RHT_CHILD_ALTAR_STONES].GetHintMessage();
     }
     if (ctx->GetOption(RSK_DOOR_OF_TIME).Is(RO_DOOROFTIME_OPEN)) {
-        hintText += CustomMessage(StaticData::hintTextTable[RHT_CHILD_ALTAR_TEXT_END_DOTOPEN].GetMessage());
+        hintText += CustomMessage(StaticData::hintTextTable[RHT_CHILD_ALTAR_TEXT_END_DOTOPEN].GetHintMessage());
     } else if (ctx->GetOption(RSK_DOOR_OF_TIME).Is(RO_DOOROFTIME_SONGONLY)) {
-        hintText += CustomMessage(StaticData::hintTextTable[RHT_CHILD_ALTAR_TEXT_END_DOTSONGONLY].GetMessage());
+        hintText += CustomMessage(StaticData::hintTextTable[RHT_CHILD_ALTAR_TEXT_END_DOTSONGONLY].GetHintMessage());
     } else {
-        hintText += CustomMessage(StaticData::hintTextTable[RHT_CHILD_ALTAR_TEXT_END_DOTCLOSED].GetMessage());
+        hintText += CustomMessage(StaticData::hintTextTable[RHT_CHILD_ALTAR_TEXT_END_DOTCLOSED].GetHintMessage());
     }
   } else if (hintType == HINT_TYPE_ALTAR_ADULT){
     if (ctx->GetOption(RSK_TOT_ALTAR_HINT)){
-      hintText = StaticData::hintTextTable[RHT_ADULT_ALTAR_MEDALLIONS].GetMessage();
+      hintText = StaticData::hintTextTable[RHT_ADULT_ALTAR_MEDALLIONS].GetHintMessage();
     }
-    hintText += GetBridgeReqsText() + GetGanonBossKeyText() + StaticData::hintTextTable[RHT_ADULT_ALTAR_TEXT_END].GetMessage();
+    hintText += GetBridgeReqsText() + GetGanonBossKeyText() + StaticData::hintTextTable[RHT_ADULT_ALTAR_TEXT_END].GetHintMessage();
   } else {
-    hintText = GetHintText(id).GetMessage(chosenMessage);
+    hintText = GetHintText(id).GetHintMessage(chosenMessage);
   }
 
   std::vector<CustomMessage> toInsert = {};
@@ -404,7 +404,7 @@ oJson Hint::toJSON() {
         } else if (locations.size() > 1){
           //If we have defaults, no need to write more
           std::vector<std::string> locStrings = {};
-          for (uint c = 0; c < locations.size(); c++){
+          for (size_t c = 0; c < locations.size(); c++){
             locStrings.push_back(StaticData::GetLocation(locations[c])->GetName());//RANDOTODO change to CustomMessage when VB is done
           }
           log["locations"] = locStrings;
@@ -417,7 +417,7 @@ oJson Hint::toJSON() {
           log["item"] = StaticData::GetItemTable()[items[0]].GetName().GetEnglish();//RANDOTODO change to CustomMessage;
         } else if (items.size() > 1){
           std::vector<std::string> itemStrings = {};
-          for (uint c = 0; c < items.size(); c++){
+          for (size_t c = 0; c < items.size(); c++){
             itemStrings.push_back(StaticData::GetItemTable()[items[c]].GetName().GetEnglish());//RANDOTODO change to CustomMessage
           }
           log["items"] = itemStrings;
@@ -428,7 +428,7 @@ oJson Hint::toJSON() {
         log["itemNameChosen"] = itemNamesChosen[0];
       } else if (itemNamesChosen.size() > 1){
         std::vector<uint8_t> nameNums = {};
-        for (uint c = 0; c < itemNamesChosen.size(); c++){
+        for (size_t c = 0; c < itemNamesChosen.size(); c++){
           nameNums.push_back(itemNamesChosen[c]);
         }
         log["itemNamesChosen"] = nameNums;
@@ -440,7 +440,7 @@ oJson Hint::toJSON() {
           !(StaticData::staticHintInfoMap.contains(ownKey) && StaticData::staticHintInfoMap[ownKey].targetChecks.size() > 0)){
       // If we got locations from defaults, areas are derived from them and don't need logging
       std::vector<std::string> areaStrings = {};
-      for (uint c = 0; c < areas.size(); c++){
+      for (size_t c = 0; c < areas.size(); c++){
         areaStrings.push_back(StaticData::hintTextTable[StaticData::areaNames[areas[c]]].GetClear().GetForCurrentLanguage(MF_CLEAN));
       }
       log["areas"] = areaStrings;
@@ -450,7 +450,7 @@ oJson Hint::toJSON() {
       log["areaNameChosen"] = areaNamesChosen[0];
     } else if (areaNamesChosen.size() > 1){
       std::vector<uint8_t> nameNums = {};
-      for (uint c = 0; c < areaNamesChosen.size(); c++){
+      for (size_t c = 0; c < areaNamesChosen.size(); c++){
         nameNums.push_back(areaNamesChosen[c]);
       }
       log["areaNamesChosen"] = nameNums;
@@ -460,7 +460,7 @@ oJson Hint::toJSON() {
       log["trial"] = ctx->GetTrial(trials[0])->GetName().GetForCurrentLanguage(MF_CLEAN);
     } else if (trials.size() > 0){
       std::vector<std::string> trialStrings = {};
-      for (uint c = 0; c < trials.size(); c++){
+      for (size_t c = 0; c < trials.size(); c++){
         trialStrings.push_back(ctx->GetTrial(trials[c])->GetName().GetForCurrentLanguage(MF_CLEAN));
       }
       log["trials"] = trialStrings;
@@ -470,7 +470,7 @@ oJson Hint::toJSON() {
       log["hintKey"] = hintKeys[0];
     } else if (hintKeys.size() > 1){
       std::vector<uint32_t> hintKeyNums = {};
-      for (uint c = 0; c < hintKeys.size(); c++){
+      for (size_t c = 0; c < hintKeys.size(); c++){
         hintKeyNums.push_back(hintKeys[c]);
       }
       log["hintKeys"] = hintKeyNums;
@@ -480,7 +480,7 @@ oJson Hint::toJSON() {
       log["hintTextChosen"] = hintTextsChosen[0];
     } else if (hintTextsChosen.size() > 1){
       std::vector<uint8_t> nameNums = {};
-      for (uint c = 0; c < hintTextsChosen.size(); c++){
+      for (size_t c = 0; c < hintTextsChosen.size(); c++){
         nameNums.push_back(hintTextsChosen[c]);
       }
       log["hintTextsChosen"] = nameNums;
@@ -534,7 +534,7 @@ const CustomMessage Hint::GetItemName(uint8_t slot, bool mysterious) const {
   if (itemNamesChosen.size() > slot){
     nameNum = itemNamesChosen[slot];
   }
-  return GetItemHintText(slot, mysterious).GetMessage(nameNum);
+  return GetItemHintText(slot, mysterious).GetHintMessage(nameNum);
 }
 
 const CustomMessage Hint::GetAreaName(uint8_t slot) const { 
@@ -542,7 +542,7 @@ const CustomMessage Hint::GetAreaName(uint8_t slot) const {
   if (areaNamesChosen.size() > slot){
     nameNum = areaNamesChosen[slot];
   }
-  return GetAreaHintText(slot).GetMessage(nameNum);
+  return GetAreaHintText(slot).GetHintMessage(nameNum);
 }
 
 
@@ -551,33 +551,33 @@ CustomMessage Hint::GetBridgeReqsText() {
   CustomMessage bridgeMessage;
 
   if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_ALWAYS_OPEN)) {
-    return StaticData::hintTextTable[RHT_BRIDGE_OPEN_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_BRIDGE_OPEN_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_VANILLA)) {
-    return StaticData::hintTextTable[RHT_BRIDGE_VANILLA_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_BRIDGE_VANILLA_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_STONES)) {
-    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_VANILLA_HINT].GetMessage();
+    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_VANILLA_HINT].GetHintMessage();
     bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_STONE_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_MEDALLIONS)) {
-    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_MEDALLIONS_HINT].GetMessage();
+    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_MEDALLIONS_HINT].GetHintMessage();
     bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_MEDALLION_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEON_REWARDS)) {
-    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_REWARDS_HINT].GetMessage();
+    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_REWARDS_HINT].GetHintMessage();
     bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_REWARD_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_DUNGEONS)) {
-    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_DUNGEONS_HINT].GetMessage();
+    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_DUNGEONS_HINT].GetHintMessage();
     bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_DUNGEON_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_TOKENS)) {
-    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_TOKENS_HINT].GetMessage();
+    bridgeMessage = StaticData::hintTextTable[RHT_BRIDGE_TOKENS_HINT].GetHintMessage();
     bridgeMessage.InsertNumber(ctx->GetOption(RSK_RAINBOW_BRIDGE_TOKEN_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_RAINBOW_BRIDGE).Is(RO_BRIDGE_GREG)) {
-    return  StaticData::hintTextTable[RHT_BRIDGE_GREG_HINT].GetMessage();
+    return  StaticData::hintTextTable[RHT_BRIDGE_GREG_HINT].GetHintMessage();
   }
   return bridgeMessage;
 }
@@ -587,51 +587,51 @@ CustomMessage Hint::GetGanonBossKeyText() {
   CustomMessage ganonBossKeyMessage;
 
   if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_STARTWITH)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_START_WITH_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_START_WITH_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_VANILLA)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_VANILLA_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_VANILLA_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_OWN_DUNGEON)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_OWN_DUNGEON_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_OWN_DUNGEON_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_ANY_DUNGEON)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_ANY_DUNGEON_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_ANY_DUNGEON_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_OVERWORLD)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_OVERWORLD_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_OVERWORLD_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_ANYWHERE)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_ANYWHERE_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_ANYWHERE_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_KAK_TOKENS)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_SKULLTULA_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_SKULLTULA_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_VANILLA)) {
-    return StaticData::hintTextTable[RHT_LACS_VANILLA_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_LACS_VANILLA_HINT].GetHintMessage();
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_STONES)) {
-    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_STONES_HINT].GetMessage();
+    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_STONES_HINT].GetHintMessage();
     ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_STONE_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_MEDALLIONS)) {
-    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_MEDALLIONS_HINT].GetMessage();
+    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_MEDALLIONS_HINT].GetHintMessage();
     ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_MEDALLION_COUNT).Value<uint8_t>());
   }
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_REWARDS)) {
-    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_REWARDS_HINT].GetMessage();
+    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_REWARDS_HINT].GetHintMessage();
     ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_REWARD_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_DUNGEONS)) {
-    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_DUNGEONS_HINT].GetMessage();
+    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_DUNGEONS_HINT].GetHintMessage();
     ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_DUNGEON_COUNT).Value<uint8_t>());
   } 
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_LACS_TOKENS)) {
-    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_TOKENS_HINT].GetMessage();
+    ganonBossKeyMessage = StaticData::hintTextTable[RHT_LACS_TOKENS_HINT].GetHintMessage();
     ganonBossKeyMessage.InsertNumber(ctx->GetOption(RSK_LACS_TOKEN_COUNT).Value<uint8_t>());
   }
   else if (ctx->GetOption(RSK_GANONS_BOSS_KEY).Is(RO_GANON_BOSS_KEY_TRIFORCE_HUNT)) {
-    return StaticData::hintTextTable[RHT_GANON_BK_TRIFORCE_HINT].GetMessage();
+    return StaticData::hintTextTable[RHT_GANON_BK_TRIFORCE_HINT].GetHintMessage();
   }
   return ganonBossKeyMessage;
 }

--- a/soh/soh/Enhancements/randomizer/hint.h
+++ b/soh/soh/Enhancements/randomizer/hint.h
@@ -34,7 +34,7 @@ class Hint {
      void NamesChosen();
      uint8_t GetNumberOfMessages() const;
      const std::vector<std::string> GetAllMessageStrings(MessageFormat format = MF_AUTO_FORMAT) const ;
-     const CustomMessage GetMessage(MessageFormat format = MF_AUTO_FORMAT, uint8_t id = 0) const ;
+     const CustomMessage GetHintMessage(MessageFormat format = MF_AUTO_FORMAT, uint8_t id = 0) const ;
      const HintText GetHintText(uint8_t id = 0) const;
      oJson toJSON();
      void logHint(oJson& jsonData);

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -2408,7 +2408,7 @@ CustomMessage Randomizer::GetSheikMessage(s16 scene, u16 originalTextId) {
             break;
         case SCENE_INSIDE_GANONS_CASTLE:
             if (ctx->GetOption(RSK_SHEIK_LA_HINT) && INV_CONTENT(ITEM_ARROW_LIGHT) != ITEM_ARROW_LIGHT) {
-                messageEntry = ctx->GetHint(RH_SHEIK_HINT)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(RH_SHEIK_HINT)->GetHintMessage(MF_AUTO_FORMAT);
             } else if (!(CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER) && INV_CONTENT(ITEM_ARROW_LIGHT) == ITEM_ARROW_LIGHT &&
                        CUR_CAPACITY(UPG_QUIVER) >= 30 && gSaveContext.isMagicAcquired)) {
                 messageEntry = CustomMessage("You are still ill-equipped to&face %rGanondorf%w."
@@ -2441,7 +2441,7 @@ CustomMessage Randomizer::GetFishingPondOwnerMessage(u16 originalTextId) {
     );
 
     if (Rando::Context::GetInstance()->GetOption(RSK_FISHING_POLE_HINT)) {
-        messageEntry = messageEntry + CustomMessage(ctx->GetHint(RH_FISHING_POLE)->GetMessage());
+        messageEntry = messageEntry + CustomMessage(ctx->GetHint(RH_FISHING_POLE)->GetHintMessage());
     }
 
     // if the fishing pond guy doesnt remember me i will cry :(
@@ -2465,7 +2465,7 @@ CustomMessage Randomizer::GetMerchantMessage(RandomizerInf randomizerInf, u16 te
     RandomizerGet shopItemGet = ctx->GetItemLocation(rc)->GetPlacedRandomizerGet();
     CustomMessage shopItemName;
     if (mysterious) {
-        shopItemName = Rando::StaticData::hintTextTable[RHT_MYSTERIOUS_ITEM].GetMessage(); 
+        shopItemName = Rando::StaticData::hintTextTable[RHT_MYSTERIOUS_ITEM].GetHintMessage(); 
     // TODO: This should eventually be replaced with a full fledged trick model & trick name system
     } else if (shopItemGet == RG_ICE_TRAP) {
         shopItemGet = ctx->overrides[rc].LooksLike();
@@ -2527,9 +2527,9 @@ CustomMessage Randomizer::GetMapGetItemMessageWithHint(GetItemEntry itemEntry) {
        ) {
         messageEntry.Replace("[[typeHint]]", "");
     } else if (ResourceMgr_IsSceneMasterQuest(sceneNum)) {
-        messageEntry.Replace("[[typeHint]]", Rando::StaticData::hintTextTable[RHT_DUNGEON_MASTERFUL].GetMessage());
+        messageEntry.Replace("[[typeHint]]", Rando::StaticData::hintTextTable[RHT_DUNGEON_MASTERFUL].GetHintMessage());
     } else {
-        messageEntry.Replace("[[typeHint]]", Rando::StaticData::hintTextTable[RHT_DUNGEON_ORDINARY].GetMessage());
+        messageEntry.Replace("[[typeHint]]", Rando::StaticData::hintTextTable[RHT_DUNGEON_ORDINARY].GetHintMessage());
     }
 
     return messageEntry;

--- a/soh/soh/Enhancements/randomizer/trial.cpp
+++ b/soh/soh/Enhancements/randomizer/trial.cpp
@@ -7,7 +7,7 @@ TrialInfo::TrialInfo() = default;
 TrialInfo::~TrialInfo() = default;
 
 CustomMessage TrialInfo::GetName() const {
-    return StaticData::hintTextTable[nameKey].GetMessage();
+    return StaticData::hintTextTable[nameKey].GetHintMessage();
 }
 
 RandomizerHintTextKey TrialInfo::GetNameKey() const {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2543,21 +2543,21 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
             if (stoneHint == RH_NONE){
                 messageEntry = CustomMessage("INVALID STONE. PARAMS: " + std::to_string(hintParams));
             } else {
-                messageEntry = ctx->GetHint(stoneHint)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(stoneHint)->GetHintMessage(MF_AUTO_FORMAT);
             }
         } else if ((textId == TEXT_ALTAR_CHILD || textId == TEXT_ALTAR_ADULT)) {
             // rando hints at altar
-            messageEntry = (LINK_IS_ADULT) ? ctx->GetHint(RH_ALTAR_ADULT)->GetMessage() : ctx->GetHint(RH_ALTAR_CHILD)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = (LINK_IS_ADULT) ? ctx->GetHint(RH_ALTAR_ADULT)->GetHintMessage() : ctx->GetHint(RH_ALTAR_CHILD)->GetHintMessage(MF_AUTO_FORMAT);
         } else if (textId == TEXT_GANONDORF) {
             if (ctx->GetOption(RSK_GANONDORF_HINT)){
                 if (ctx->GetOption(RSK_SHUFFLE_MASTER_SWORD) && !CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER)){
                     messageEntry = INV_CONTENT(ITEM_ARROW_LIGHT) == ITEM_ARROW_LIGHT ?
-                                   ctx->GetHint(RH_GANONDORF_HINT)->GetMessage(MF_AUTO_FORMAT, 1):
-                                   ctx->GetHint(RH_GANONDORF_HINT)->GetMessage(MF_AUTO_FORMAT, 2);
+                                   ctx->GetHint(RH_GANONDORF_HINT)->GetHintMessage(MF_AUTO_FORMAT, 1):
+                                   ctx->GetHint(RH_GANONDORF_HINT)->GetHintMessage(MF_AUTO_FORMAT, 2);
                 } else {
                     messageEntry = INV_CONTENT(ITEM_ARROW_LIGHT) == ITEM_ARROW_LIGHT ?
-                                   ctx->GetHint(RH_GANONDORF_JOKE)->GetMessage(MF_AUTO_FORMAT):
-                                   ctx->GetHint(RH_GANONDORF_HINT)->GetMessage(MF_AUTO_FORMAT, 0);
+                                   ctx->GetHint(RH_GANONDORF_JOKE)->GetHintMessage(MF_AUTO_FORMAT):
+                                   ctx->GetHint(RH_GANONDORF_HINT)->GetHintMessage(MF_AUTO_FORMAT, 0);
                 }
             }
         } else if (textId == TEXT_SHEIK_NEED_HOOK || textId == TEXT_SHEIK_HAVE_HOOK) {
@@ -2587,20 +2587,20 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(Randomizer::NaviRandoMessageTableID, naviTextId);
         } 
         else if (textId == TEXT_BEAN_SALESMAN_BUY_FOR_10 && ctx->GetOption(RSK_SHUFFLE_MAGIC_BEANS)) {
-            messageEntry = ctx->GetHint(RH_BEAN_SALESMAN)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = ctx->GetHint(RH_BEAN_SALESMAN)->GetHintMessage(MF_AUTO_FORMAT);
         } 
         else if (textId == TEXT_BEAN_SALESMAN_BUY_FOR_100) {
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(Randomizer::merchantMessageTableID, TEXT_BEAN_SALESMAN_BUY_FOR_100);
         } 
         else if (textId == TEXT_GRANNYS_SHOP && !Flags_GetRandomizerInf(RAND_INF_MERCHANTS_GRANNYS_SHOP) && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF &&
             (ctx->GetOption(RSK_SHUFFLE_ADULT_TRADE) || INV_CONTENT(ITEM_CLAIM_CHECK) == ITEM_CLAIM_CHECK)){
-            messageEntry = messageEntry = ctx->GetHint(RH_GRANNY)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = messageEntry = ctx->GetHint(RH_GRANNY)->GetHintMessage(MF_AUTO_FORMAT);
         } 
         else if (textId == TEXT_MEDIGORON && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF){
-            messageEntry = messageEntry = ctx->GetHint(RH_MEDIGORON)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = messageEntry = ctx->GetHint(RH_MEDIGORON)->GetHintMessage(MF_AUTO_FORMAT);
         } 
         else if (textId == TEXT_CARPET_SALESMAN_1 && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF){
-            messageEntry = messageEntry = ctx->GetHint(RH_CARPET_SALESMAN)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = messageEntry = ctx->GetHint(RH_CARPET_SALESMAN)->GetHintMessage(MF_AUTO_FORMAT);
         } 
         else if (textId == TEXT_CARPET_SALESMAN_2 && Randomizer_GetSettingValue(RSK_SHUFFLE_MERCHANTS) != RO_SHUFFLE_MERCHANTS_OFF){
             messageEntry = CustomMessageManager::Instance->RetrieveMessage(Randomizer::merchantMessageTableID, textId);
@@ -2612,40 +2612,40 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
         else if (textId == TEXT_SKULLTULA_PEOPLE_IM_CURSED) {
             actorParams = GET_PLAYER(play)->targetActor->params;
             if (actorParams == 1 && ctx->GetOption(RSK_KAK_10_SKULLS_HINT)){
-                messageEntry = ctx->GetHint(RH_KAK_10_SKULLS_HINT)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(RH_KAK_10_SKULLS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
             } else if (actorParams == 2 && ctx->GetOption(RSK_KAK_20_SKULLS_HINT)){
-                messageEntry = ctx->GetHint(RH_KAK_20_SKULLS_HINT)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(RH_KAK_20_SKULLS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
             } else if (actorParams == 3 && ctx->GetOption(RSK_KAK_30_SKULLS_HINT)){
-                messageEntry = ctx->GetHint(RH_KAK_30_SKULLS_HINT)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(RH_KAK_30_SKULLS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
             } else if (actorParams == 4 && ctx->GetOption(RSK_KAK_40_SKULLS_HINT)){
-                messageEntry = ctx->GetHint(RH_KAK_40_SKULLS_HINT)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(RH_KAK_40_SKULLS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
             } else if (ctx->GetOption(RSK_KAK_50_SKULLS_HINT)){
-                messageEntry = ctx->GetHint(RH_KAK_50_SKULLS_HINT)->GetMessage(MF_AUTO_FORMAT);
+                messageEntry = ctx->GetHint(RH_KAK_50_SKULLS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
             }
         } else if (textId == TEXT_DAMPES_DIARY && ctx->GetOption(RSK_DAMPES_DIARY_HINT)) {
-            messageEntry = ctx->GetHint(RH_DAMPES_DIARY)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = ctx->GetHint(RH_DAMPES_DIARY)->GetHintMessage(MF_AUTO_FORMAT);
         }
         else if ((textId == TEXT_CHEST_GAME_PROCEED || textId == TEXT_CHEST_GAME_REAL_GAMBLER || textId == TEXT_CHEST_GAME_THANKS_A_LOT) &&
                    play->sceneNum == SCENE_TREASURE_BOX_SHOP && ctx->GetOption(RSK_GREG_HINT)) {
-            messageEntry = ctx->GetHint(RH_GREG_RUPEE)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = ctx->GetHint(RH_GREG_RUPEE)->GetHintMessage(MF_AUTO_FORMAT);
         }
         else if (textId == TEXT_WARP_MINUET_OF_FOREST && ctx->GetOption(RSK_WARP_SONG_HINTS)) {
-            messageEntry = ctx->GetHint(RH_MINUET_WARP_LOC)->GetMessage(MF_FORMATTED);
+            messageEntry = ctx->GetHint(RH_MINUET_WARP_LOC)->GetHintMessage(MF_FORMATTED);
         }
         else if (textId == TEXT_WARP_BOLERO_OF_FIRE && ctx->GetOption(RSK_WARP_SONG_HINTS)) {
-            messageEntry = ctx->GetHint(RH_BOLERO_WARP_LOC)->GetMessage(MF_FORMATTED);
+            messageEntry = ctx->GetHint(RH_BOLERO_WARP_LOC)->GetHintMessage(MF_FORMATTED);
         }
         else if (textId == TEXT_WARP_SERENADE_OF_WATER && ctx->GetOption(RSK_WARP_SONG_HINTS)) {
-            messageEntry = ctx->GetHint(RH_SERENADE_WARP_LOC)->GetMessage(MF_FORMATTED);
+            messageEntry = ctx->GetHint(RH_SERENADE_WARP_LOC)->GetHintMessage(MF_FORMATTED);
         }
         else if (textId == TEXT_WARP_REQUIEM_OF_SPIRIT && ctx->GetOption(RSK_WARP_SONG_HINTS)) {
-            messageEntry = ctx->GetHint(RH_REQUIEM_WARP_LOC)->GetMessage(MF_FORMATTED);
+            messageEntry = ctx->GetHint(RH_REQUIEM_WARP_LOC)->GetHintMessage(MF_FORMATTED);
         }
         else if (textId == TEXT_WARP_NOCTURNE_OF_SHADOW && ctx->GetOption(RSK_WARP_SONG_HINTS)) {
-            messageEntry = ctx->GetHint(RH_NOCTURNE_WARP_LOC)->GetMessage(MF_FORMATTED);
+            messageEntry = ctx->GetHint(RH_NOCTURNE_WARP_LOC)->GetHintMessage(MF_FORMATTED);
         }
         else if (textId == TEXT_WARP_PRELUDE_OF_LIGHT && ctx->GetOption(RSK_WARP_SONG_HINTS)) {
-            messageEntry = ctx->GetHint(RH_PRELUDE_WARP_LOC)->GetMessage(MF_FORMATTED);
+            messageEntry = ctx->GetHint(RH_PRELUDE_WARP_LOC)->GetHintMessage(MF_FORMATTED);
         }
         else if (textId >= TEXT_WARP_MINUET_OF_FOREST &&  textId <= TEXT_WARP_PRELUDE_OF_LIGHT 
                  && ctx->GetOption(RSK_SHUFFLE_WARP_SONGS)) {
@@ -2662,53 +2662,53 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
             messageEntry = OTRGlobals::Instance->gRandomizer->GetGoronMessage(choice);
         }
         else if (textId == TEXT_FROGS_UNDERWATER && ctx->GetOption(RSK_FROGS_HINT)) {
-           messageEntry = ctx->GetHint(RH_FROGS_HINT)->GetMessage(MF_AUTO_FORMAT), TEXTBOX_TYPE_BLUE;
+           messageEntry = ctx->GetHint(RH_FROGS_HINT)->GetHintMessage(MF_AUTO_FORMAT), TEXTBOX_TYPE_BLUE;
         }
         else if ((textId == TEXT_FISHING_POND_START || textId == TEXT_FISHING_POND_START_MET) && 
                    ctx->GetOption(RSK_SHUFFLE_FISHING_POLE) && !Flags_GetRandomizerInf(RAND_INF_FISHING_POLE_FOUND)) {
             messageEntry = OTRGlobals::Instance->gRandomizer->GetFishingPondOwnerMessage(textId);
         }
         else if (textId == TEXT_SARIA_SFM && gPlayState->sceneNum == SCENE_SACRED_FOREST_MEADOW && ctx->GetOption(RSK_SARIA_HINT)){
-            messageEntry = ctx->GetHint(RH_SARIA_HINT)->GetMessage(MF_AUTO_FORMAT, 0);
+            messageEntry = ctx->GetHint(RH_SARIA_HINT)->GetHintMessage(MF_AUTO_FORMAT, 0);
         }
         else if ((textId >= TEXT_SARIAS_SONG_FACE_TO_FACE && textId <= TEXT_SARIAS_SONG_CHANNELING_POWER) && ctx->GetOption(RSK_SARIA_HINT)){
-            messageEntry = ctx->GetHint(RH_SARIA_HINT)->GetMessage(MF_AUTO_FORMAT, 1);
+            messageEntry = ctx->GetHint(RH_SARIA_HINT)->GetHintMessage(MF_AUTO_FORMAT, 1);
         }
         else if (ctx->GetOption(RSK_BIGGORON_HINT) && (textId == TEXT_BIGGORON_BETTER_AT_SMITHING || textId ==  TEXT_BIGGORON_WAITING_FOR_YOU || textId ==  TEXT_BIGGORON_RETURN_AFTER_A_FEW_DAYS)) {
-           messageEntry = ctx->GetHint(RH_BIGGORON_HINT)->GetMessage(MF_AUTO_FORMAT);
+           messageEntry = ctx->GetHint(RH_BIGGORON_HINT)->GetHintMessage(MF_AUTO_FORMAT);
         }
         else if (ctx->GetOption(RSK_BIG_POES_HINT) && (textId == TEXT_GHOST_SHOP_EXPLAINATION || textId == TEXT_GHOST_SHOP_CARD_HAS_POINTS)) {
-            messageEntry = ctx->GetHint(RH_BIG_POES_HINT)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = ctx->GetHint(RH_BIG_POES_HINT)->GetHintMessage(MF_AUTO_FORMAT);
         }
         else if (ctx->GetOption(RSK_CHICKENS_HINT) && (textId >= TEXT_ANJU_PLEASE_BRING_MY_CUCCOS_BACK && textId <= TEXT_ANJU_PLEASE_BRING_1_CUCCO)) {
-            messageEntry = ctx->GetHint(RH_CHICKENS_HINT)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = ctx->GetHint(RH_CHICKENS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
         }
         else if ((textId == TEXT_MALON_EVERYONE_TURNING_EVIL || textId == TEXT_MALON_I_SING_THIS_SONG)&& ctx->GetOption(RSK_MALON_HINT)){
-            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetMessage(MF_AUTO_FORMAT, 0);
+            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetHintMessage(MF_AUTO_FORMAT, 0);
         }
         else if (textId == TEXT_MALON_HOW_IS_EPONA_DOING && ctx->GetOption(RSK_MALON_HINT)){
-            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetMessage(MF_AUTO_FORMAT, 1);
+            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetHintMessage(MF_AUTO_FORMAT, 1);
         }
         else if (textId == TEXT_MALON_OBSTICLE_COURSE && ctx->GetOption(RSK_MALON_HINT)){
-            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetMessage(MF_AUTO_FORMAT, 2);
+            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetHintMessage(MF_AUTO_FORMAT, 2);
         }
         else if (textId == TEXT_MALON_INGO_MUST_HAVE_BEEN_TEMPTED && ctx->GetOption(RSK_MALON_HINT)){
-            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetMessage(MF_AUTO_FORMAT, 3);
+            messageEntry = ctx->GetHint(RH_MALON_HINT)->GetHintMessage(MF_AUTO_FORMAT, 3);
         }
         else if (ctx->GetOption(RSK_KAK_100_SKULLS_HINT) && textId == TEXT_SKULLTULA_PEOPLE_MAKE_YOU_VERY_RICH) {
-            messageEntry = ctx->GetHint(RH_KAK_100_SKULLS_HINT)->GetMessage(MF_AUTO_FORMAT);
+            messageEntry = ctx->GetHint(RH_KAK_100_SKULLS_HINT)->GetHintMessage(MF_AUTO_FORMAT);
         }
         else if (textId == TEXT_GF_HBA_SIGN && ctx->GetOption(RSK_HBA_HINT)) {
-            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetMessage(MF_AUTO_FORMAT, 0);
+            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetHintMessage(MF_AUTO_FORMAT, 0);
         }
         else if (textId == TEXT_HBA_NOT_ON_HORSE && ctx->GetOption(RSK_HBA_HINT)) {
-            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetMessage(MF_AUTO_FORMAT, 1);
+            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetHintMessage(MF_AUTO_FORMAT, 1);
         }
         else if (textId == TEXT_HBA_INITIAL_EXPLAINATION && ctx->GetOption(RSK_HBA_HINT)) {
-            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetMessage(MF_AUTO_FORMAT, 2);
+            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetHintMessage(MF_AUTO_FORMAT, 2);
         }
         else if (textId == TEXT_HBA_ALREADY_HAVE_1000 && ctx->GetOption(RSK_HBA_HINT)) {
-            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetMessage(MF_AUTO_FORMAT, 3);
+            messageEntry = ctx->GetHint(RH_HBA_HINT)->GetHintMessage(MF_AUTO_FORMAT, 3);
         }
     }
     if (textId == TEXT_GS_NO_FREEZE || textId == TEXT_GS_FREEZE) {


### PR DESCRIPTION
Renames GetMessage to GetHintMessage (a different name could be chosen, but GetMessage conflicts with a macro in winuser.h) Changes uint to size_t, uint does not seem to exist on Windows. Also removes an unnecessary std::move that was preventing copy elision.